### PR TITLE
composer dependencies fixed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "silex/silex": "1.0.*",
-        "leafo/lessphp": "dev-master"
+        "silex/silex": "~1.1",
+        "leafo/lessphp": "~0.4"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
As mentioned in this issue, it's currently not possible to install this provider:
https://github.com/darklow/ff-silex-less-provider/issues/5
